### PR TITLE
Use headless Chrome for Selenium

### DIFF
--- a/src/scrape.py
+++ b/src/scrape.py
@@ -15,14 +15,16 @@ from newspaper.article import ArticleException
 
 def parse_article(url):
     r = requests.get(url)
-    if r.status_code != 200:
+    if r.status_code == 404:
         raise ValueError("URL not found: %s" % url)
     article = Article(url)
     try:
         article.download()
         article.parse()
     except:
-        driver = webdriver.Chrome()
+        options = webdriver.ChromeOptions()
+        options.add_argument("headless")
+        driver = webdriver.Chrome(chrome_options=options)
         driver.get(url)
         article.download(input_html=driver.page_source)
         article.parse()


### PR DESCRIPTION
* Added the option to use headless Chrome for Selenium 
* Changed the status code check to skip 404 specifically, to address the comment from @JoeLayne, since the errors I was seeing in Chrome were mostly 404s.